### PR TITLE
Updated Javascript and Ruby on Rails DB Model to account for the *reserved word* 'end' it is now 'ends'

### DIFF
--- a/app/assets/javascripts/full_calendar.js
+++ b/app/assets/javascripts/full_calendar.js
@@ -26,11 +26,11 @@ initialize_calendar = function() {
       },
 
       eventDrop: function(event, delta, revertFunc) {
-        event_data = { 
+        event_data = {
           event: {
             id: event.id,
             start: event.start.format(),
-            end: event.end.format()
+            ends: event.end.format()
           }
         };
         $.ajax({
@@ -39,7 +39,7 @@ initialize_calendar = function() {
             type: 'PATCH'
         });
       },
-      
+
       eventClick: function(event, jsEvent, view) {
         $.getScript(event.edit_url, function() {
           $('#event_date_range').val(moment(event.start).format("MM/DD/YYYY HH:mm") + ' - ' + moment(event.end).format("MM/DD/YYYY HH:mm"))
@@ -52,4 +52,3 @@ initialize_calendar = function() {
   })
 };
 $(document).on('turbolinks:load', initialize_calendar);
-

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   before_action :set_event, only: [:show, :edit, :update, :destroy]
 
   def index
-    @events = Event.where(start: params[:start]..params[:end])
+    @events = Event.where(start: params[:start]..params[:ends])
   end
 
   def show
@@ -34,6 +34,6 @@ class EventsController < ApplicationController
     end
 
     def event_params
-      params.require(:event).permit(:title, :date_range, :start, :end, :color)
+      params.require(:event).permit(:title, :date_range, :start, :ends, :color)
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,6 @@ class Event < ApplicationRecord
   attr_accessor :date_range
 
   def all_day_event?
-    self.start == self.start.midnight && self.end == self.end.midnight ? true : false
+    self.start == self.start.midnight && self.ends == self.ends.midnight ? true : false
   end
 end

--- a/app/views/events/_event.json.jbuilder
+++ b/app/views/events/_event.json.jbuilder
@@ -3,7 +3,7 @@ date_format = event.all_day_event? ? '%Y-%m-%d' : '%Y-%m-%dT%H:%M:%S'
 json.id event.id
 json.title event.title
 json.start event.start.strftime(date_format)
-json.end event.end.strftime(date_format)
+json.end event.ends.strftime(date_format)
 
 json.color event.color unless event.color.blank?
 json.allDay event.all_day_event? ? true : false

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -3,17 +3,17 @@
     <%= f.input :title %>
     <%= f.input :date_range, input_html: { class: "form-control input-sm date-range-picker" } %>
     <%= f.input_field :start, as: :hidden, value: Date.today, class: 'form-control input-sm start_hidden' %>
-    <%= f.input_field :end, as: :hidden, value: Date.today, class: 'form-control input-sm end_hidden' %>
+    <%= f.input_field :ends, as: :hidden, value: Date.today, class: 'form-control input-sm end_hidden' %>
     <%= f.input :color, as: :select, collection: [['Black','black'], ['Green','green'], ['Red','red']] %>
   </div>
 
   <div class="form-actions">
     <%= f.button :submit %>
-    <%= link_to 'Delete', 
-                event, 
-                method: :delete, 
-                class: 'btn btn-danger', 
-                data: { confirm: 'Are you sure?' }, 
+    <%= link_to 'Delete',
+                event,
+                method: :delete,
+                class: 'btn btn-danger',
+                data: { confirm: 'Are you sure?' },
                 remote: true unless @event.new_record? %>
   </div>
 <% end %>

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -3,7 +3,7 @@ json.array! @events do |event|
   json.id event.id
   json.title event.title
   json.start event.start.strftime(date_format)
-  json.end event.end.strftime(date_format)
+  json.end event.ends.strftime(date_format)
   json.color event.color unless event.color.blank?
   json.allDay event.all_day_event? ? true : false
   json.update_url event_path(event, method: :patch)

--- a/db/migrate/20160814032341_create_events.rb
+++ b/db/migrate/20160814032341_create_events.rb
@@ -3,7 +3,7 @@ class CreateEvents < ActiveRecord::Migration[5.0]
     create_table :events do |t|
       t.string :title
       t.datetime :start
-      t.datetime :end
+      t.datetime :ends
       t.string :color
 
       t.timestamps


### PR DESCRIPTION
The reserved word 'end' that we used in the database caused some issues with my application when I needed to make some special Active Record queries like 

`...where('end > ?', Date.today)
`

I changed the word 'end' to 'ends' so it remained intuitive (and was easy to update on all of my files). I hope I got all of the reserved words out of Ruby code. I ran it on my end and it went fine, but perhaps I got lucky. If it is all fixed, Active Record queries now look like

`...where('ends > ?', Date.today)
` 